### PR TITLE
Make colours consistent for Wants summary

### DIFF
--- a/app/models/concerns/chartkick_grouping.rb
+++ b/app/models/concerns/chartkick_grouping.rb
@@ -25,6 +25,8 @@ module ChartkickGrouping
           item[label_key.to_sym] = value_name if value_name
         end
 
+        yield item if block_given?
+
         list << item
       end
     end


### PR DESCRIPTION
Add a `WANTS_TO_COLOR` hash in WantsDailySummary, and allow
`group_for_chartkick` to yield an item. Fill the color in for
the series in a block.