### PR TITLE
Use a linkRowUsing option to timeline

### DIFF
--- a/app/controllers/ad_codes_controller.rb
+++ b/app/controllers/ad_codes_controller.rb
@@ -23,7 +23,8 @@ class AdCodesController < ApplicationController
     @values = ValueDailySummary.between(@campaign, @ad_code.index, start, finish, dimension: dimension)
     @options = {
       rowHeight: DENSITY_ROWHEIGHTS[params[:density] || 'spacious'],
-      svgClass: "utm#{@ad_code.index}"
+      svgClass: "utm#{@ad_code.index}",
+      linkRowUsing: 'pathToAdCodeValue'
     }
 
     breadcrumb "#{@ad_code.full_name} / Timeline", request.path

--- a/app/javascript/packs/timeline.js
+++ b/app/javascript/packs/timeline.js
@@ -15,6 +15,9 @@ class Timeline {
     this.svgClass = options['svgClass']
     this.circleRange = options['circleRange'] || [3, 25]
     this.width = 930 - this.margin.left - this.margin.right
+    if(options['linkRowUsing'] === 'pathToAdCodeValue') {
+      this.linkRowUsing = this.pathToAdCodeValue
+    }
   }
 
   get svg() {
@@ -80,10 +83,9 @@ class Timeline {
 
     this.drawExtentLines(groups, x)
 
-    groups
-      .append("a")
-      .attr("href", (d) => this.pathToAdCodeValue(d))
-      .on("click", this.dismissTooltip.bind(this))
+    const links = this.linkIndividualRow(groups)
+
+    links
       .append("rect")
       .attr('class', 'highlight')
       .attr('x', 0)
@@ -118,6 +120,16 @@ class Timeline {
 
     groups.append('svg:title').text((d) => d.name)
     this.groups = groups
+  }
+
+  linkIndividualRow(groups) {
+    if(this.linkRowUsing)
+      return groups
+        .append("a")
+        .attr("href", (d) => this.linkRowUsing(d))
+        .on("click", this.dismissTooltip.bind(this));
+
+    return groups;
   }
 
   pathToAdCodeValue(d) {

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -3,6 +3,13 @@
 <%= content_for :title, 'Campaign hosts' %>
 <h1>Campaign hosts</h1>
 
-<%= timeline(@host_ad_counts, rowHeight: 18, circleRange: [3, 16], svgClass: 'hosts') %>
+<%=
+  timeline(
+    @host_ad_counts,
+    rowHeight: 18,
+    circleRange: [3, 16],
+    svgClass: 'hosts'
+  )
+%>
 
 <%= render 'hosts_table' %>


### PR DESCRIPTION
This lets us specify the function that does the linking with
client-side routing. Normally it's undefined, so no linking
takes place.

Fixes Rollbar #19 or going to /campaigns/undefined/ad_codes/undefined etc