### PR TITLE
Add adverts.impressions bounds (CPM part 1)

### DIFF
--- a/db/migrate/20201027094942_add_impressions_bounds.rb
+++ b/db/migrate/20201027094942_add_impressions_bounds.rb
@@ -1,0 +1,6 @@
+class AddImpressionsBounds < ActiveRecord::Migration[6.0]
+  def change
+    add_column :adverts, :impressions_lower_bound, :integer
+    add_column :adverts, :impressions_upper_bound, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_22_132058) do
+ActiveRecord::Schema.define(version: 2020_10_27_094942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -83,6 +83,8 @@ ActiveRecord::Schema.define(version: 2020_10_22_132058) do
     t.integer "spend_upper_bound"
     t.jsonb "illuminate_tags"
     t.string "wants_key"
+    t.integer "impressions_lower_bound"
+    t.integer "impressions_upper_bound"
     t.index ["external_url"], name: "index_adverts_on_external_url", using: :hash
     t.index ["funding_entity_id"], name: "index_adverts_on_funding_entity_id"
     t.index ["host_id"], name: "index_adverts_on_host_id"

--- a/lib/tasks/ads.rake
+++ b/lib/tasks/ads.rake
@@ -44,13 +44,12 @@ namespace :ads do
   namespace :backfill do
     desc 'backfill impressions month to month. Larger sets cause infinite* queries'
     task impressions: :environment do
-      oldest_month = 6
-      this_month = Date.today.month
-      (oldest_month..this_month).each do |month|
+      oldest_day = Date.new(2020, 6, 1)
+      (oldest_day..Date.today).each do |day|
         system(
           "make clean impressions.csv update-impressions \\
-            IMPRESSIONS_FROM=2020-#{month}-01 \\
-            IMPRESSIONS_TO=2020-#{(month + 1) % 12}-01"
+            IMPRESSIONS_FROM=#{day.iso8601} \\
+            IMPRESSIONS_TO=#{(day + 1).iso8601}"
         )
       end
     end


### PR DESCRIPTION
And backfill them daily from June (monthly no longer works)

Because of the auto-migrate on deploy, deploy this first and run the rake task to backfill impressions
afterwards. We can deploy the UI when the values are present.